### PR TITLE
Add STM32L4 support

### DIFF
--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -12,8 +12,10 @@
 #include "stm32f1xx_hal.h"
 #elif defined(STM32F4)
 #include "stm32f4xx_hal.h"
+#elif defined(STM32L4)
+#include "stm32l4xx_hal.h"
 #else
-#error "SSD1306 library was tested only on STM32F1 and STM32F4 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
+#error "SSD1306 library was tested only on STM32F1, STM32F4, STM32L4 MCU families. Please modify ssd1306.h if you know what you are doing. Also please send a pull request if it turns out the library works on other MCU's as well!"
 #endif
 
 #include "ssd1306_fonts.h"

--- a/ssd1306/ssd1306.h
+++ b/ssd1306/ssd1306.h
@@ -8,6 +8,8 @@
 #ifndef __SSD1306_H__
 #define __SSD1306_H__
 
+#include <stddef.h>
+
 #if defined(STM32F1)
 #include "stm32f1xx_hal.h"
 #elif defined(STM32F4)

--- a/ssd1306/ssd1306_tests.c
+++ b/ssd1306/ssd1306_tests.c
@@ -1,5 +1,6 @@
 #include "ssd1306.h"
 #include <string.h>
+#include <stdio.h>
 
 void ssd1306_TestBorder() {
     ssd1306_Fill(Black);


### PR DESCRIPTION
I tested this with an STM32L476RG Nucleo board and an SSD1306 I2C OLED (128x64).
![LongWays2](https://user-images.githubusercontent.com/547550/60759950-b808d780-9ff2-11e9-983b-dd94f7e2e30f.jpg)
